### PR TITLE
Fixing caret up and right icons

### DIFF
--- a/public/svg/filled/caret-right.svg
+++ b/public/svg/filled/caret-right.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.071 5L7.70708 11.364C7.31656 11.7545 7.31656 12.3877 7.70708 12.7782L14.071 19.1421" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9.92896 4.85785L16.2929 11.2218C16.6834 11.6123 16.6834 12.2455 16.2929 12.636L9.92896 19" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
 </svg>

--- a/public/svg/filled/caret-up.svg
+++ b/public/svg/filled/caret-up.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.99976 9.92896L11.3637 16.2929C11.7542 16.6834 12.3874 16.6834 12.7779 16.2929L19.1419 9.92895" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M4.99976 14.071L11.3637 7.70708C11.7542 7.31656 12.3874 7.31656 12.7779 7.70708L19.1419 14.071" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
 </svg>

--- a/public/svg/outline/caret-right.svg
+++ b/public/svg/outline/caret-right.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.071 5L7.70708 11.364C7.31656 11.7545 7.31656 12.3877 7.70708 12.7782L14.071 19.1421" stroke="black" stroke-linecap="round"/>
+<path d="M9.92896 4.85785L16.2929 11.2218C16.6834 11.6123 16.6834 12.2455 16.2929 12.636L9.92896 19" stroke="black" stroke-linecap="round"/>
 </svg>

--- a/public/svg/outline/caret-up.svg
+++ b/public/svg/outline/caret-up.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.99957 9.92865L11.3635 16.2926C11.7541 16.6831 12.3872 16.6831 12.7777 16.2926L19.1417 9.92865" stroke="black" stroke-linecap="round"/>
+<path d="M5 14.0711L11.364 7.70711C11.7545 7.31658 12.3877 7.31658 12.7782 7.70711L19.1421 14.0711" stroke="black" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
Those were pointing in the wrong direction after export prep due to mysterious Figma weirdness (no idea why, had to recreate them).