### PR TITLE
Added module info, copy to clipboard buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@bitcoin-design/bitcoin-icons-vue": "^0.1.6",
+        "@bitcoin-design/bitcoin-icons-vue": "^0.1.7",
         "core-js": "^3.6.5",
         "inter-ui": "^3.19.3",
         "sass": "^1.39.2",
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/@bitcoin-design/bitcoin-icons-vue": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bitcoin-design/bitcoin-icons-vue/-/bitcoin-icons-vue-0.1.6.tgz",
-      "integrity": "sha512-yw1HOUH8+lqvbBXBLJBznfLFkEJkexKsIz1PMKSBN7JQJOmDt+xCU91mU1YceibjEMI0LHeOFrz3llPzadSjDg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@bitcoin-design/bitcoin-icons-vue/-/bitcoin-icons-vue-0.1.7.tgz",
+      "integrity": "sha512-nP1T9s2zKmsgrA892LSGPEv8DZkmj3WhgaxyUYB35DiHTbXZA+YnLFI+PxASILgHUGfkwJDcBZWnPg0At7zVcA==",
       "peerDependencies": {
         "vue": ">= 3"
       }
@@ -17572,9 +17572,9 @@
       }
     },
     "@bitcoin-design/bitcoin-icons-vue": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bitcoin-design/bitcoin-icons-vue/-/bitcoin-icons-vue-0.1.6.tgz",
-      "integrity": "sha512-yw1HOUH8+lqvbBXBLJBznfLFkEJkexKsIz1PMKSBN7JQJOmDt+xCU91mU1YceibjEMI0LHeOFrz3llPzadSjDg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@bitcoin-design/bitcoin-icons-vue/-/bitcoin-icons-vue-0.1.7.tgz",
+      "integrity": "sha512-nP1T9s2zKmsgrA892LSGPEv8DZkmj3WhgaxyUYB35DiHTbXZA+YnLFI+PxASILgHUGfkwJDcBZWnPg0At7zVcA==",
       "requires": {}
     },
     "@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@bitcoin-design/bitcoin-icons-vue": "^0.1.6",
+    "@bitcoin-design/bitcoin-icons-vue": "^0.1.7",
     "core-js": "^3.6.5",
     "inter-ui": "^3.19.3",
     "sass": "^1.39.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@
         @close="closeOverlay"
       />
       <SiteInfo />
+      <ModuleInfo />
       <SiteFooter />
     </div>
   </div>
@@ -39,6 +40,7 @@ import SiteHeader from './components/SiteHeader.vue'
 import OptionsBar from './components/OptionsBar.vue'
 import IconGrid from './components/IconGrid.vue'
 import SiteInfo from './components/SiteInfo.vue'
+import ModuleInfo from './components/ModuleInfo.vue'
 import SiteFooter from './components/SiteFooter.vue'
 import IconOverlay from './components/IconOverlay/IconOverlay.vue'
 
@@ -52,6 +54,7 @@ export default {
     OptionsBar,
     IconGrid,
     SiteInfo,
+    ModuleInfo,
     IconOverlay,
     SiteFooter
   },
@@ -66,21 +69,17 @@ export default {
       activeIcon: null,
       isMobile: false,
       links: [
-        // {
-        //   name: 'Download',
-        //   url: 'https://github.com/BitcoinDesign/Bitcoin-Icons'
-        // },
         {
-          name: 'Download on Github',
-          url: 'https://github.com/BitcoinDesign/Bitcoin-Icons'
+          name: 'Download',
+          url: 'https://github.com/BitcoinDesign/Bitcoin-Icons/releases/latest/download/package.zip'
         },
         {
-          name: 'Contribute on Figma',
+          name: 'Figma',
           url: 'https://www.figma.com/community/file/948545404023677970/Bitcoin-icon-set'
-        // },
-        // {
-        //   name: 'Contribute',
-        //   url: 'https://github.com/BitcoinDesign/Bitcoin-Icons'
+        },
+        {
+          name: 'Github',
+          url: 'https://github.com/BitcoinDesign/Bitcoin-Icons'
         }
       ]
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@ export default {
       links: [
         {
           name: 'Download',
-          url: 'https://github.com/BitcoinDesign/Bitcoin-Icons/releases/latest/download/package.zip'
+          url: 'https://github.com/BitcoinDesign/Bitcoin-Icons/archive/refs/tags/v0.1.7.zip'
         },
         {
           name: 'Figma',

--- a/src/components/IconOverlay/IconOverlay.vue
+++ b/src/components/IconOverlay/IconOverlay.vue
@@ -13,11 +13,13 @@
       <IconOverlaySection
         v-if="!isMobile || (isMobile && styleOptionModel == 'filled')"
         styleName="filled"
+        :isMobile="isMobile"
         :iconData="activeIcon"
       />
       <IconOverlaySection
         v-if="!isMobile || (isMobile && styleOptionModel == 'outline')"
         styleName="outline"
+        :isMobile="isMobile"
         :iconData="activeIcon"
       />
     </div>
@@ -108,7 +110,6 @@ export default {
 
   methods: {
     setStyleOption(value) {
-      console.log('ss', value);
       this.styleOptionModel = value
     },
 

--- a/src/components/IconOverlay/Section.vue
+++ b/src/components/IconOverlay/Section.vue
@@ -4,9 +4,17 @@
       <transition name="icon-fade" mode="out-in">
         <div class="icon" :key="iconData.id">
           <component
+            ref="bigIcon"
             :is="iconComponentName"
             :alt="iconData.data.name"
           />
+          <button
+            v-if="!isMobile && clipboardAvailable"
+            :class="copyButtonClass"
+            @click="clickCopy"
+          >
+            <CopyIconFilled />
+          </button>
         </div>
       </transition>
       <div class="small-icons">
@@ -49,7 +57,21 @@ export default {
 
   props: {
     styleName: String,
+    isMobile: Boolean,
     iconData: Object
+  },
+
+  data() {
+    return {
+      clipboardAvailable: navigator.clipboard,
+      copyButtonClicked: false
+    }
+  },
+
+  watch: {
+    iconData() {
+      this.copyButtonClicked = false
+    }
   },
 
   computed: {
@@ -63,6 +85,28 @@ export default {
       }
 
       return result
+    },
+
+    copyButtonClass() {
+      const c = []
+
+      if(this.copyButtonClicked) {
+        c.push('-active')
+      }
+
+      return c
+    }
+  },
+
+  methods: {
+    clickCopy() {
+      const bigIcon = this.$refs.bigIcon
+      const svgCode = bigIcon.outerHTML
+      navigator.clipboard.writeText(svgCode).then(() => {
+
+      })
+
+      this.copyButtonClicked = true
     }
   }
 }
@@ -138,8 +182,9 @@ export default {
   > .icon {
     border-bottom: $borderWidth solid rgba(var(--frontRGB), var(--borderOpacity));
     padding: 30px;
+    position: relative;
 
-    svg {
+    > svg {
       width: 100%;
       height: auto;
       color: var(--front);
@@ -153,6 +198,40 @@ export default {
     &.icon-fade-enter,
     &.icon-fade-leave-to {
       opacity: 0;
+    }
+
+    button {
+      display: block;
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      padding: 0;
+      appearance: none;
+      border-width: 0;
+      background-color: transparent;
+      opacity: 0;
+      color: var(--front);
+      transition: all 100ms $ease;
+
+      svg {
+        width: 30px;
+        height: 30px;
+      }
+
+      &.-active {
+        color: $primary;
+        animation: copyBounce 0.5s $easeInOutCubic 1;
+      }
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 0.5;
+
+      &:hover {
+        opacity: 1;
+      }
     }
   }
 
@@ -168,23 +247,37 @@ export default {
   @include media-query(medium-up) {
     flex-basis: 45%;
   }
+
+  @include media-query(small) {
+
+  }
+
+  @include media-query(medium-up) {
+
+  }
 }
 
 .--theme-dark {
   .icon-overlay-section {
-    .small-icons {
-      .icon {
-        img {
-          filter: invert(100%);
-        }
-      }
-    }
 
-    > .icon {
-      img {
-        filter: invert(100%);
-      }
-    }
+  }
+}
+
+@keyframes copyBounce {
+  0% {
+    transform: scale(1, 1);
+  }
+
+  25% {
+    transform: scale(0.75, 0.75);
+  }
+
+  75% {
+    transform: scale(1.25, 1.25);
+  }
+
+  100% {
+    transform: scale(1, 1);
   }
 }
 

--- a/src/components/IconOverlay/StylePicker.vue
+++ b/src/components/IconOverlay/StylePicker.vue
@@ -38,7 +38,6 @@ export default {
 
   methods: {
     setStyleOption(value) {
-      console.log('ss', value);
       this.$emit('setStyleOption', value)
     }
   }

--- a/src/components/ModuleInfo.vue
+++ b/src/components/ModuleInfo.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="module-info">
+    <div class="module">
+      <div class="copy">
+        <h2>Vue module</h2>
+        <a
+          href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-vue" 
+          rel="nofollow" 
+        >
+          <img
+            src="https://img.shields.io/npm/v/@bitcoin-design/bitcoin-icons-vue.svg?style=flat-square"
+            alt="Vue module npm version" 
+          >
+        </a>
+        <a
+          href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-vue"
+          rel="nofollow"
+        >
+          <img
+            src="https://img.shields.io/npm/dm/@bitcoin-design/bitcoin-icons-vue.svg?style=flat-square"
+            alt="Vue module npm downloads"
+          >
+        </a>
+      </div>
+      <a href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-vue">Get it</a>
+    </div>
+    <div class="module">
+      <div class="copy">
+        <h2>React module</h2>
+        <a
+          href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-react" 
+          rel="nofollow" 
+        >
+          <img
+            src="https://img.shields.io/npm/v/@bitcoin-design/bitcoin-icons-react.svg?style=flat-square"
+            alt="React module npm version" 
+          >
+        </a>
+        <a
+          href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-react"
+          rel="nofollow"
+        >
+          <img
+            src="https://img.shields.io/npm/dm/@bitcoin-design/bitcoin-icons-react.svg?style=flat-square"
+            alt="React module npm downloads"
+          >
+        </a>
+      </div>
+      <a href="https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-react">Get it</a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ModuleInfo',
+
+  props: {
+
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+@import "../scss/variables.scss";
+@import "../scss/mixins.scss";
+@import "../scss/animations.scss";
+
+.module-info {
+  display: flex;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+  @include r('margin-top', 40, 80);
+  padding-left: 10px;
+  padding-right: 10px;
+
+  .module {
+    text-align: center;
+      
+    .copy {
+      h2  {
+        margin: 0;
+        @include r('font-size', 22, 27);
+        @include r('letter-spacing', -0.5, -1);
+        font-weight: 400;
+        color: var(--front);
+      }
+
+      a {
+        margin-top: 10px;
+        display: inline-block;
+
+        & + a {
+          margin-left: 5px;
+        }
+      }
+    }
+
+    > a {
+      margin: 20px 0 0 0;
+      display: inline-block;
+      border: 2px solid var(--front);
+      color: var(--front);
+      text-decoration: none;
+      line-height: 40px;
+      padding: 0 20px;
+      font-weight: 600;
+      transition: all 100ms $ease;
+
+      svg {
+        display: inline-block;
+        vertical-align: middle;
+        width: 24px;
+        height: 24px;
+        transition: all 150ms $ease;
+        transform: translate(0, -2px);
+      }
+
+      img {
+        filter: invert(100%);
+        vertical-align: middle;
+        display: inline-block;
+        margin-left: 10px;
+        transition: all 150ms $ease;
+      }
+
+      &:hover {
+        border-color: $primary;
+        color: $primary;
+      }
+    }
+  }
+
+  @include media-query(small) {
+    flex-direction: column;
+    
+    .module {
+      & + .module {
+        @include r('margin-top', 40, 80);
+      }
+    }
+  }
+
+  @include media-query(medium-up) {
+    .module {
+      flex-grow: 1;
+    }
+  }
+}
+
+.--theme-dark {
+  .site-info {
+
+  }
+}
+
+</style>


### PR DESCRIPTION
Added a direct download link at the top.
Added direct links to the modules at the bottom.
Added a copy button in the overlay to copy/paste the SVG code.

Only merge this once the [0.1.7 release](https://github.com/BitcoinDesign/Bitcoin-Icons/milestone/1) of the [Bitcoin-Icons](https://github.com/BitcoinDesign/Bitcoin-Icons) repo is live, so the direct download button actually works, and the new Vue module version can  be updated for this site.